### PR TITLE
fix: add new api parameter

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -196,6 +196,11 @@ func resourcePipeline() *schema.Resource {
 							Optional: true,
 							Default:  true,
 						},
+						"build_pull_request_ready_for_review": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 						"pull_request_branch_filter_enabled": &schema.Schema{
 							Type:     schema.TypeBool,
 							Optional: true,


### PR DESCRIPTION
Buildkite added a new API parameter that breaks the pipeline resource.

I'm very new to go. Is there any way to change the `resource_pipeline` so that it can just ignore the API parameters instead of failing with `Error: Invalid address to set: []string{"github_settings", "0", "build_pull_request_ready_for_review"}` every time Buildkite adds a property?