### PR TITLE
add build branches github setting

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -254,6 +254,10 @@ func resourcePipeline() *schema.Resource {
 							Optional: true,
 							Default:  true,
 						},
+						"build_branches": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 						"build_tags": &schema.Schema{
 							Type:     schema.TypeBool,
 							Optional: true,


### PR DESCRIPTION
Fixes the error `Error: Invalid address to set: []string{"github_settings", "0", "build_branches"}` that recently started appearing.

Also: have y'all considered dynamically parsing the json for Github settings? It seems that issues like this pop up frequently enough that it might be worth refactoring. That way nobody runs into issues like this in the future. 