### PR TITLE
Add commit_status_404s to github_settings

### DIFF
--- a/buildkite/resource_pipeline.go
+++ b/buildkite/resource_pipeline.go
@@ -279,6 +279,10 @@ func resourcePipeline() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"commit_status_404s": &schema.Schema{
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Fix this issue that just pops up today:

```
Error: Invalid address to set: []string{"github_settings", "0", "commit_status_404s"}
```

It appears to be a computed value.